### PR TITLE
Removing course tagline from config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,4 @@
 title: # a name for your Learning Lab course
-tagline: # a short description for your Learning Lab course, displayed on the course catalog
 description: # a longer description for your Learning Lab course, displayed on the course's landing page
 
 # Repository setup


### PR DESCRIPTION
We're no longer using the course tagline in Learning Lab, so removing it from the boilerplate as part of updating the docs!